### PR TITLE
feat: add guestlist management with auth

### DIFF
--- a/my-app/src/app/api/guests/route.ts
+++ b/my-app/src/app/api/guests/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Guest } from '@/types';
+
+let guests: Guest[] = [];
+
+const isAuthorized = (req: NextRequest): boolean => {
+  const authHeader = req.headers.get('authorization');
+  return authHeader === `Bearer ${process.env.GUESTLIST_PASSWORD}`;
+};
+
+export const GET = async (req: NextRequest) => {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  return NextResponse.json(guests);
+};
+
+export const POST = async (req: NextRequest) => {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const guest = (await req.json()) as Guest;
+  const newGuest: Guest = { ...guest, id: guest.id || Date.now().toString() };
+  guests.push(newGuest);
+  return NextResponse.json(newGuest, { status: 201 });
+};
+
+export const DELETE = async (req: NextRequest) => {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get('id');
+  guests = guests.filter((g) => g.id !== id);
+  return NextResponse.json({ success: true });
+};

--- a/my-app/src/app/guestlist/page.tsx
+++ b/my-app/src/app/guestlist/page.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState, useEffect } from 'react';
+import { Guest } from '@/types';
+import { fetchGuests, addGuest, deleteGuest } from '@/utils/guestlist';
+
+export default function GuestlistPage() {
+  const [password, setPassword] = useState('');
+  const [token, setToken] = useState('');
+  const [isAuth, setIsAuth] = useState(false);
+  const [guests, setGuests] = useState<Guest[]>([]);
+  const [newGuest, setNewGuest] = useState<Omit<Guest, 'id'>>({
+    name: '',
+    email: '',
+    attending: true,
+  });
+
+  useEffect(() => {
+    const saved = localStorage.getItem('guestlist_token');
+    if (saved) {
+      fetchGuests(saved)
+        .then((data) => {
+          setToken(saved);
+          setGuests(data);
+          setIsAuth(true);
+        })
+        .catch(() => {
+          localStorage.removeItem('guestlist_token');
+        });
+    }
+  }, []);
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const data = await fetchGuests(password);
+      setToken(password);
+      localStorage.setItem('guestlist_token', password);
+      setGuests(data);
+      setIsAuth(true);
+    } catch {
+      alert('Feil passord');
+    }
+  };
+
+  const handleAddGuest = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const added = await addGuest(newGuest, token);
+      setGuests((prev) => [...prev, added]);
+      setNewGuest({ name: '', email: '', attending: true });
+    } catch {
+      alert('Kunne ikke legge til gjest');
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteGuest(id, token);
+      setGuests((prev) => prev.filter((g) => g.id !== id));
+    } catch {
+      alert('Kunne ikke slette gjest');
+    }
+  };
+
+  if (!isAuth) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen">
+        <form onSubmit={handleLogin} className="space-y-4">
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Passord"
+            className="border p-2"
+          />
+          <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded">
+            Logg inn
+          </button>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-8 max-w-xl mx-auto">
+      <h1 className="text-2xl mb-4">Gjesteliste</h1>
+      <ul className="mb-8">
+        {guests.map((guest) => (
+          <li key={guest.id} className="flex justify-between items-center mb-2">
+            <span>
+              {guest.name} {guest.attending ? '(Kommer)' : '(Kommer ikke)'}
+            </span>
+            <button
+              onClick={() => handleDelete(guest.id)}
+              className="text-red-500 hover:underline"
+            >
+              Slett
+            </button>
+          </li>
+        ))}
+      </ul>
+      <form onSubmit={handleAddGuest} className="space-y-4">
+        <input
+          type="text"
+          value={newGuest.name}
+          onChange={(e) => setNewGuest({ ...newGuest, name: e.target.value })}
+          placeholder="Navn"
+          className="border p-2 w-full"
+          required
+        />
+        <input
+          type="email"
+          value={newGuest.email}
+          onChange={(e) => setNewGuest({ ...newGuest, email: e.target.value })}
+          placeholder="E-post (valgfritt)"
+          className="border p-2 w-full"
+        />
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            checked={newGuest.attending}
+            onChange={(e) =>
+              setNewGuest({ ...newGuest, attending: e.target.checked })
+            }
+          />
+          <span>Kommer</span>
+        </label>
+        <button type="submit" className="px-4 py-2 bg-green-500 text-white rounded">
+          Legg til gjest
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/my-app/src/types/index.ts
+++ b/my-app/src/types/index.ts
@@ -52,3 +52,10 @@ export interface CountdownCardProps {
   gradient: string;
   animationDelay: number;
 }
+
+export interface Guest {
+  id: string;
+  name: string;
+  email?: string;
+  attending: boolean;
+}

--- a/my-app/src/utils/guestlist.ts
+++ b/my-app/src/utils/guestlist.ts
@@ -1,0 +1,48 @@
+import { Guest } from '@/types';
+
+const API_URL = '/api/guests';
+
+export const fetchGuests = async (token: string): Promise<Guest[]> => {
+  const res = await fetch(API_URL, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    cache: 'no-store',
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch guests');
+  }
+
+  return res.json();
+};
+
+export const addGuest = async (guest: Omit<Guest, 'id'>, token: string): Promise<Guest> => {
+  const res = await fetch(API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(guest),
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to add guest');
+  }
+
+  return res.json();
+};
+
+export const deleteGuest = async (id: string, token: string): Promise<void> => {
+  const res = await fetch(`${API_URL}?id=${id}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to delete guest');
+  }
+};


### PR DESCRIPTION
## Summary
- add guest fetching/saving utilities
- create guestlist page with basic password login
- add API route securing guestlist operations

## Testing
- `npm run lint`
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Failed to fetch `Cormorant Garamond` from Google Fonts.)

------
https://chatgpt.com/codex/tasks/task_e_68b2fcb8a5c08329bedcea25a6dca82d