### PR TITLE
feat: add notification service worker

### DIFF
--- a/my-app/public/sw.js
+++ b/my-app/public/sw.js
@@ -1,0 +1,27 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+const MILESTONES = [30, 7, 1]; // days before wedding
+
+function scheduleNotification(days, weddingDate) {
+  const targetTime = new Date(weddingDate).getTime() - days * 24 * 60 * 60 * 1000;
+  const timeUntil = targetTime - Date.now();
+  const show = () => self.registration.showNotification('Bryllupet nærmer seg!', {
+    body: `${days} dager igjen til bryllupet!`,
+    icon: '/romantic-silhouette.svg',
+  });
+  if (timeUntil <= 0) {
+    show();
+  } else if (timeUntil <= 2147483647) {
+    setTimeout(show, timeUntil);
+  }
+}
+
+self.addEventListener('message', (event) => {
+  if (event.data?.type === 'scheduleNotifications') {
+    const weddingDate = event.data.weddingDate;
+    MILESTONES.forEach((days) => scheduleNotification(days, weddingDate));
+  }
+});


### PR DESCRIPTION
## Summary
- integrate service worker with Notification API to fire milestone alerts
- register worker and add UI to request notification permissions

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font file from `https://fonts.gstatic.com/...` )*

------
https://chatgpt.com/codex/tasks/task_e_68b2fcbaad7c8329ab599891e05a62d0