### PR TITLE
Add PWA manifest and service worker

### DIFF
--- a/my-app/public/manifest.json
+++ b/my-app/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "Alexandra & Tobias - Bryllup 2026",
+  "short_name": "Bryllup",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/next.svg",
+      "type": "image/svg+xml",
+      "sizes": "any"
+    }
+  ]
+}

--- a/my-app/public/sw.js
+++ b/my-app/public/sw.js
@@ -1,0 +1,14 @@
+const CACHE_NAME = 'offline-cache-v1';
+const OFFLINE_URL = '/';
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll([OFFLINE_URL]))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});

--- a/my-app/src/app/layout.tsx
+++ b/my-app/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Parisienne, Playfair_Display, Cormorant_Garamond, Dancing_Script } from 'next/font/google';
+import Script from "next/script";
 import "./globals.css";
 
 const parisienne = Parisienne({
@@ -54,9 +55,19 @@ export default function RootLayout({
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link href="https://fonts.googleapis.com/css2?family=Parisienne:wght@400&family=Dancing+Script:wght@400;500;600;700&display=swap" rel="stylesheet" />
+        <link rel="manifest" href="/manifest.json" />
       </head>
       <body className="antialiased font-sans">
         {children}
+        <Script id="service-worker-registration">
+          {`
+            if ('serviceWorker' in navigator) {
+              window.addEventListener('load', () => {
+                navigator.serviceWorker.register('/sw.js');
+              });
+            }
+          `}
+        </Script>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- add web app manifest and basic service worker
- register service worker and link manifest in layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google font files)*
- `npx -y lighthouse http://localhost:3001 --only-categories=pwa --chrome-flags="--headless"` *(fails: The CHROME_PATH environment variable must be set to a Chrome/Chromium executable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fcbb9f14832995f0ebdf926e17cb