### PR TITLE
Add internationalization with language selector

### DIFF
--- a/my-app/package-lock.json
+++ b/my-app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "15.5.2",
+        "next-intl": "^4.3.5",
         "react": "19.1.0",
         "react-dom": "19.1.0"
       },
@@ -209,6 +210,66 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz",
+      "integrity": "sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/@humanfs/core": {
@@ -975,6 +1036,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -2464,6 +2531,12 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3650,6 +3723,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -4643,6 +4728,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next": {
       "version": "15.5.2",
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.2.tgz",
@@ -4691,6 +4785,33 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.3.5.tgz",
+      "integrity": "sha512-tT3SltfpPOCAQ9kVNr+8t6FUtVf8G0WFlJcVc8zj4WCMfuF8XFk4gZCN/MtjgDgkUISw5aKamOClJB4EsV95WQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.5.4",
+        "negotiator": "^1.0.0",
+        "use-intl": "^4.3.5"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0",
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
           "optional": true
         }
       }
@@ -5930,7 +6051,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -6009,6 +6130,20 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-intl": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.3.5.tgz",
+      "integrity": "sha512-qyL1TZNesVbzj/75ZbYsi+xzNSiFqp5rIVsiAN0JT8rPMSjX0/3KQz76aJIrngI1/wIQdVYFVdImWh5yAv+dWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^2.2.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "intl-messageformat": "^10.5.14"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/which": {

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -9,19 +9,20 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "next": "15.5.2",
+    "next-intl": "^4.3.5",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.5.2"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.5.2",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/my-app/public/locales/en.json
+++ b/my-app/public/locales/en.json
@@ -1,0 +1,25 @@
+{
+  "common": {
+    "loading": "Loading wedding website...",
+    "scrollToTop": "Scroll to top"
+  },
+  "countdown": {
+    "days": "Days",
+    "hours": "Hours",
+    "minutes": "Minutes",
+    "seconds": "Seconds"
+  },
+  "hero": {
+    "saveTheDate": "Save the date",
+    "date": "July 24, 2026",
+    "location": "Østgaard, Halden"
+  },
+  "footer": {
+    "heading": "Alexandra & Tobias",
+    "tagline": "We look forward to sharing this special day with you 👩‍❤️‍💋‍👨",
+    "contact": "Contact",
+    "copyright": "© {year} Alexandra & Tobias. All rights reserved.",
+    "madeWith": "Made with ❤️ from Saltnes",
+    "language": "Language"
+  }
+}

--- a/my-app/public/locales/no.json
+++ b/my-app/public/locales/no.json
@@ -1,0 +1,25 @@
+{
+  "common": {
+    "loading": "Laster bryllupsnettside...",
+    "scrollToTop": "Rull til toppen"
+  },
+  "countdown": {
+    "days": "Dager",
+    "hours": "Timer",
+    "minutes": "Minutter",
+    "seconds": "Sekunder"
+  },
+  "hero": {
+    "saveTheDate": "Save the date",
+    "date": "24. juli 2026",
+    "location": "Østgaard, Halden"
+  },
+  "footer": {
+    "heading": "Alexandra & Tobias",
+    "tagline": "Vi gleder oss til å dele denne spesielle dagen med dere 👩‍❤️‍💋‍👨",
+    "contact": "Kontakt",
+    "copyright": "© {year} Alexandra & Tobias. Alle rettigheter forbeholdt.",
+    "madeWith": "Laget med ❤️ fra Saltnes",
+    "language": "Språk"
+  }
+}

--- a/my-app/src/app/layout.tsx
+++ b/my-app/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Parisienne, Playfair_Display, Cormorant_Garamond, Dancing_Script } from 'next/font/google';
 import "./globals.css";
+import { IntlProvider } from '@/components/IntlProvider';
 
 const parisienne = Parisienne({
   weight: '400',
@@ -56,7 +57,9 @@ export default function RootLayout({
         <link href="https://fonts.googleapis.com/css2?family=Parisienne:wght@400&family=Dancing+Script:wght@400;500;600;700&display=swap" rel="stylesheet" />
       </head>
       <body className="antialiased font-sans">
-        {children}
+        <IntlProvider>
+          {children}
+        </IntlProvider>
       </body>
     </html>
   );

--- a/my-app/src/app/page.tsx
+++ b/my-app/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { TimeLeft } from "@/types";
 import { calculateTimeLeft, WEDDING_DATE } from "@/utils/dateUtils";
+import { useTranslations } from 'next-intl';
 import { 
   HeroSection, 
   StorySection, 
@@ -12,6 +13,7 @@ import {
 } from "@/components";
 
 export default function Home() {
+  const t = useTranslations('common');
   const [timeLeft, setTimeLeft] = useState<TimeLeft>({
     days: 0,
     hours: 0,
@@ -69,7 +71,7 @@ export default function Home() {
         <div className="fixed inset-0 z-50 bg-gradient-to-br from-[#FEFAE0] to-[#F4D1D4] flex items-center justify-center">
           <div className="text-center">
             <div className="w-16 h-16 border-4 border-[#E8B4B8] border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
-            <p className="font-body text-[#2D1B3D] text-lg">Laster bryllupsnettside...</p>
+            <p className="font-body text-[#2D1B3D] text-lg">{t('loading')}</p>
           </div>
         </div>
       )}
@@ -91,7 +93,7 @@ export default function Home() {
       <button
         onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
         className="fixed bottom-8 right-8 w-12 h-12 bg-gradient-to-r from-[#E8B4B8] to-[#F4A261] text-white rounded-full shadow-2xl hover-lift transition-all duration-300 opacity-0 hover:opacity-100 group z-40"
-        aria-label="Rull til toppen"
+        aria-label={t('scrollToTop')}
         style={{
           opacity: typeof window !== 'undefined' && window.scrollY > 500 ? 1 : 0
         }}

--- a/my-app/src/components/CountdownTimer.tsx
+++ b/my-app/src/components/CountdownTimer.tsx
@@ -1,16 +1,20 @@
+"use client";
+
 import { CountdownCard } from './CountdownCard';
 import { TimeLeft } from '@/types';
+import { useTranslations } from 'next-intl';
 
 interface CountdownTimerProps {
   timeLeft: TimeLeft;
 }
 
 export const CountdownTimer: React.FC<CountdownTimerProps> = ({ timeLeft }) => {
+  const t = useTranslations('countdown');
   const countdownItems = [
-    { label: 'Dager', value: timeLeft.days, color: 'from-[#E8B4B8]/75 to-[#F4A261]/75' },
-    { label: 'Timer', value: timeLeft.hours, color: 'from-[#F4A261]/75 to-[#E76F51]/75' },
-    { label: 'Minutter', value: timeLeft.minutes, color: 'from-[#E76F51]/75 to-[#4A2B5A]/75' },
-    { label: 'Sekunder', value: timeLeft.seconds, color: 'from-[#4A2B5A]/75 to-[#E8B4B8]/75' }
+    { label: t('days'), value: timeLeft.days, color: 'from-[#E8B4B8]/75 to-[#F4A261]/75' },
+    { label: t('hours'), value: timeLeft.hours, color: 'from-[#F4A261]/75 to-[#E76F51]/75' },
+    { label: t('minutes'), value: timeLeft.minutes, color: 'from-[#E76F51]/75 to-[#4A2B5A]/75' },
+    { label: t('seconds'), value: timeLeft.seconds, color: 'from-[#4A2B5A]/75 to-[#E8B4B8]/75' }
   ];
 
   return (

--- a/my-app/src/components/Footer.tsx
+++ b/my-app/src/components/Footer.tsx
@@ -1,7 +1,13 @@
+"use client";
+
 import { FooterProps } from '@/types';
+import { useTranslations } from 'next-intl';
+import { useLocaleContext } from './IntlProvider';
 
 export const Footer: React.FC<FooterProps> = () => {
   const currentYear = new Date().getFullYear();
+  const t = useTranslations('footer');
+  const { locale, setLocale } = useLocaleContext();
 
   return (
     <footer className="bg-gradient-to-br from-[#2D1B3D] via-[#4A2B5A] to-[#2D1B3D] text-white relative overflow-hidden">
@@ -13,19 +19,19 @@ export const Footer: React.FC<FooterProps> = () => {
           {/* Main footer content */}
           <div className="space-y-6">
             <h3 className="font-display text-3xl md:text-4xl text-white mb-4">
-              Alexandra & Tobias
+              {t('heading')}
             </h3>
             
             <div className="w-24 h-1 bg-gradient-to-r from-[#E8B4B8] to-[#F4A261] mx-auto rounded-full"></div>
             
             <p className="font-body text-lg text-white/80 max-w-2xl mx-auto leading-relaxed">
-              Vi gleder oss til å dele denne spesielle dagen med dere 👩‍❤️‍💋‍👨
+              {t('tagline')}
             </p>
           </div>
           
           {/* Contact information */}
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-6 border border-white/20 max-w-2xl mx-auto">
-            <h4 className="font-body font-medium text-white mb-4">Kontakt</h4>
+            <h4 className="font-body font-medium text-white mb-4">{t('contact')}</h4>
             <div className="grid md:grid-cols-2 gap-4 text-base">
               <div className="text-center">
                 <p className="font-body text-white/80">Alexandra</p>
@@ -44,11 +50,25 @@ export const Footer: React.FC<FooterProps> = () => {
           {/* Copyright */}
           <div className="text-center">
             <p className="font-body-light text-white/60">
-              © {currentYear} Alexandra & Tobias. Alle rettigheter forbeholdt.
+              {t('copyright', {year: currentYear})}
             </p>
             <p className="font-small text-white/40 mt-2">
-              Laget med ❤️ fra Saltnes
+              {t('madeWith')}
             </p>
+            <div className="mt-4">
+              <label htmlFor="language-select" className="sr-only">
+                {t('language')}
+              </label>
+              <select
+                id="language-select"
+                value={locale}
+                onChange={(e) => setLocale(e.target.value as 'no' | 'en')}
+                className="bg-white/10 text-white px-3 py-1 rounded-md"
+              >
+                <option value="no">Norsk</option>
+                <option value="en">English</option>
+              </select>
+            </div>
           </div>
         </div>
       </div>

--- a/my-app/src/components/HeroSection.tsx
+++ b/my-app/src/components/HeroSection.tsx
@@ -1,12 +1,16 @@
+"use client";
+
 import { useState, useEffect, useRef } from "react";
 import { CountdownTimer } from './CountdownTimer';
 // import { calculateTimeLeft, WEDDING_DATE } from '@/utils/dateUtils';
 import { HeroSectionProps } from '@/types';
+import { useTranslations } from 'next-intl';
 
 export const HeroSection: React.FC<HeroSectionProps> = ({ timeLeft }) => {
   const [isVisible, setIsVisible] = useState(false);
   const heroRef = useRef<HTMLElement>(null);
   const bgRef = useRef<HTMLDivElement>(null);
+  const t = useTranslations('hero');
 
   useEffect(() => {
     const timer = setTimeout(() => setIsVisible(true), 100);
@@ -83,11 +87,11 @@ export const HeroSection: React.FC<HeroSectionProps> = ({ timeLeft }) => {
                aria-hidden="true"></div>
         </header>
 
-        <p className="font-body-light text-xl md:text-2xl lg:text-3xl text-white/95 mb-10 tracking-wide animate-fade-in-up" 
+        <p className="font-body-light text-xl md:text-2xl lg:text-3xl text-white/95 mb-10 tracking-wide animate-fade-in-up"
            style={{ animationDelay: '0.8s' }}>
-          Save the date
+          {t('saveTheDate')}
           <br />
-          24. juli 2026
+          {t('date')}
         </p>
 
         {/* Countdown */}
@@ -97,7 +101,7 @@ export const HeroSection: React.FC<HeroSectionProps> = ({ timeLeft }) => {
 
         {/* Date/time as simple text (no box) */}
         <div className="mt-8 animate-fade-in-up" style={{ animationDelay: '1.2s' }}>
-          <p className="font-body text-xl md:text-2xl text-white/95 mb-1 font-medium">Østgaard, Halden</p>
+          <p className="font-body text-xl md:text-2xl text-white/95 mb-1 font-medium">{t('location')}</p>
         </div>
 
         {/* Scroll indicator - positioned 30px below bottom */}

--- a/my-app/src/components/IntlProvider.tsx
+++ b/my-app/src/components/IntlProvider.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import {ReactNode, createContext, useContext, useState} from 'react';
+import {NextIntlClientProvider} from 'next-intl';
+import no from '../../public/locales/no.json';
+import en from '../../public/locales/en.json';
+
+const messages = {no, en} as const;
+type Locale = keyof typeof messages;
+
+interface LocaleContextType {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+}
+
+const LocaleContext = createContext<LocaleContextType>({
+  locale: 'no',
+  setLocale: () => {}
+});
+
+export function useLocaleContext() {
+  return useContext(LocaleContext);
+}
+
+export function IntlProvider({children}: {children: ReactNode}) {
+  const [locale, setLocale] = useState<Locale>('no');
+
+  return (
+    <LocaleContext.Provider value={{locale, setLocale}}>
+      <NextIntlClientProvider locale={locale} messages={messages[locale]}>
+        {children}
+      </NextIntlClientProvider>
+    </LocaleContext.Provider>
+  );
+}

--- a/my-app/src/components/index.ts
+++ b/my-app/src/components/index.ts
@@ -6,3 +6,4 @@ export { StorySection } from './StorySection';
 export { WeddingDetailsSection } from './WeddingDetailsSection';
 export { RSVPSection } from './RSVPSection';
 export { Footer } from './Footer';
+export { IntlProvider, useLocaleContext } from './IntlProvider';


### PR DESCRIPTION
## Summary
- Install `next-intl` and add shared `IntlProvider`
- Move UI strings into translation files under `public/locales`
- Hook up components to translations and add a language switcher in the footer

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2fcbcc5e48329928eac83050ba23c