### PR TITLE
Add Jest testing setup and CountdownTimer tests

### DIFF
--- a/my-app/jest.config.js
+++ b/my-app/jest.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 const nextJest = require('next/jest');
 
 const createJestConfig = nextJest({
@@ -8,6 +9,9 @@ const createJestConfig = nextJest({
 const customJestConfig = {
   testEnvironment: 'jest-environment-jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
 };
 
 module.exports = createJestConfig(customJestConfig);


### PR DESCRIPTION
## Summary
- set up Jest with React Testing Library and jsdom environment
- add configuration and setup files for testing
- add tests for `CountdownTimer` component rendering and props
- map `@/` imports in Jest

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b301705c188329bdd3affc35c76663