### PR TITLE
Add story image upload and management for Vår historie

### DIFF
--- a/my-app/next.config.ts
+++ b/my-app/next.config.ts
@@ -3,6 +3,13 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   images: {
     formats: ['image/webp', 'image/avif'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**.supabase.co',
+        pathname: '/storage/v1/object/public/**',
+      },
+    ],
   },
   experimental: {
     optimizePackageImports: ['lucide-react'],

--- a/my-app/src/app/api/admin/story-images/route.ts
+++ b/my-app/src/app/api/admin/story-images/route.ts
@@ -1,0 +1,141 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyCookie, logSecurityEvent, getClientIdentifier } from '@/lib/security';
+import { supabaseServer } from '@/lib/supabase';
+
+const BUCKET = 'story-images';
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+
+function isAuthenticated(request: NextRequest): boolean {
+  const session = request.cookies.get('admin_session');
+  if (!session?.value) return false;
+  return verifyCookie(session.value) === 'authenticated';
+}
+
+// GET — list all images in the bucket
+export async function GET(request: NextRequest) {
+  if (!isAuthenticated(request)) {
+    return NextResponse.json({ error: 'Ikke autentisert' }, { status: 401 });
+  }
+
+  try {
+    const supabase = supabaseServer();
+    const { data, error } = await supabase.storage.from(BUCKET).list('', {
+      sortBy: { column: 'created_at', order: 'asc' },
+    });
+
+    if (error) {
+      console.error('Error listing story images:', error);
+      return NextResponse.json({ error: 'Kunne ikke hente bilder' }, { status: 500 });
+    }
+
+    const images = (data || [])
+      .filter((f) => !f.name.startsWith('.'))
+      .map((f) => {
+        const { data: urlData } = supabase.storage.from(BUCKET).getPublicUrl(f.name);
+        return {
+          name: f.name,
+          url: urlData.publicUrl,
+          createdAt: f.created_at,
+        };
+      });
+
+    return NextResponse.json({ images });
+  } catch (error) {
+    console.error('Error listing images:', error);
+    return NextResponse.json({ error: 'Serverfeil' }, { status: 500 });
+  }
+}
+
+// POST — upload a new image
+export async function POST(request: NextRequest) {
+  const clientId = getClientIdentifier(request);
+
+  if (!isAuthenticated(request)) {
+    logSecurityEvent('unauthorized_image_upload', { clientId }, 'warning');
+    return NextResponse.json({ error: 'Ikke autentisert' }, { status: 401 });
+  }
+
+  try {
+    const formData = await request.formData();
+    const file = formData.get('file') as File | null;
+
+    if (!file) {
+      return NextResponse.json({ error: 'Ingen fil valgt' }, { status: 400 });
+    }
+
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      return NextResponse.json(
+        { error: `Ugyldig filtype. Tillatte typer: ${ALLOWED_TYPES.join(', ')}` },
+        { status: 400 },
+      );
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json({ error: 'Filen er for stor (maks 5 MB)' }, { status: 400 });
+    }
+
+    // Generate unique filename
+    const ext = file.name.split('.').pop() || 'jpg';
+    const filename = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${ext}`;
+
+    const supabase = supabaseServer();
+    const buffer = Buffer.from(await file.arrayBuffer());
+
+    const { error: uploadError } = await supabase.storage
+      .from(BUCKET)
+      .upload(filename, buffer, {
+        contentType: file.type,
+        upsert: false,
+      });
+
+    if (uploadError) {
+      console.error('Upload error:', uploadError);
+      return NextResponse.json({ error: 'Kunne ikke laste opp bilde' }, { status: 500 });
+    }
+
+    const { data: urlData } = supabase.storage.from(BUCKET).getPublicUrl(filename);
+
+    logSecurityEvent('story_image_uploaded', { clientId, filename }, 'info');
+
+    return NextResponse.json({
+      url: urlData.publicUrl,
+      name: filename,
+    });
+  } catch (error) {
+    console.error('Upload error:', error);
+    return NextResponse.json({ error: 'Serverfeil ved opplasting' }, { status: 500 });
+  }
+}
+
+// DELETE — remove an image
+export async function DELETE(request: NextRequest) {
+  const clientId = getClientIdentifier(request);
+
+  if (!isAuthenticated(request)) {
+    logSecurityEvent('unauthorized_image_delete', { clientId }, 'warning');
+    return NextResponse.json({ error: 'Ikke autentisert' }, { status: 401 });
+  }
+
+  try {
+    const { name } = await request.json();
+
+    if (!name || typeof name !== 'string') {
+      return NextResponse.json({ error: 'Mangler filnavn' }, { status: 400 });
+    }
+
+    const supabase = supabaseServer();
+    const { error } = await supabase.storage.from(BUCKET).remove([name]);
+
+    if (error) {
+      console.error('Delete error:', error);
+      return NextResponse.json({ error: 'Kunne ikke slette bilde' }, { status: 500 });
+    }
+
+    logSecurityEvent('story_image_deleted', { clientId, name }, 'info');
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Delete error:', error);
+    return NextResponse.json({ error: 'Serverfeil ved sletting' }, { status: 500 });
+  }
+}

--- a/my-app/src/app/api/content/route.ts
+++ b/my-app/src/app/api/content/route.ts
@@ -81,6 +81,14 @@ export async function GET() {
       if (!footer.hideContactText) footer.hideContactText = 'Skjul kontaktinfo';
     }
 
+    // Add default story images if missing
+    if (content.story && typeof content.story === 'object') {
+      const story = content.story as Record<string, unknown>;
+      if (!story.images) {
+        story.images = [];
+      }
+    }
+
     // Add default weddingDetails.info if missing
     if (content.weddingDetails && typeof content.weddingDetails === 'object') {
       const weddingDetails = content.weddingDetails as Record<string, unknown>;

--- a/my-app/src/components/StorySection.tsx
+++ b/my-app/src/components/StorySection.tsx
@@ -12,10 +12,17 @@ interface TimelineItem {
   text: string;
 }
 
+interface StoryImage {
+  url: string;
+  alt: string;
+  storageName?: string;
+}
+
 interface StoryContent {
   title: string;
   subtitle: string;
   timeline: TimelineItem[];
+  images?: StoryImage[];
 }
 
 interface ImageModalProps {
@@ -71,12 +78,19 @@ export const StorySection: React.FC<StorySectionProps> = () => {
   const timelineRef = useScrollReveal<HTMLOListElement>({ animationType: 'fade-left', threshold: 0.2 });
   const imagesRef = useScrollReveal<HTMLDivElement>({ animationType: 'fade-right', threshold: 0.2 });
 
-  const storyImages = useMemo(() => [
-    { src: "/images/story-1.jpg", alt: "Alexandra og Tobias", objectClass: "object-[center_30%]" },
-    { src: "/images/story-2.jpg", alt: "Alexandra og Tobias", objectClass: "object-[center_35%]" },
-    { src: "/images/story-3.jpg", alt: "Alexandra og Tobias", objectClass: "object-[center_30%]" },
-    { src: "/images/story-4.jpg", alt: "Alexandra og Tobias", objectClass: "object-[center_40%]" }
+  const defaultImages = useMemo(() => [
+    { src: "/images/story-1.jpg", alt: "Alexandra og Tobias" },
+    { src: "/images/story-2.jpg", alt: "Alexandra og Tobias" },
+    { src: "/images/story-3.jpg", alt: "Alexandra og Tobias" },
+    { src: "/images/story-4.jpg", alt: "Alexandra og Tobias" }
   ], []);
+
+  const storyImages = useMemo(() => {
+    if (content?.images && content.images.length > 0) {
+      return content.images.map((img) => ({ src: img.url, alt: img.alt }));
+    }
+    return defaultImages;
+  }, [content?.images, defaultImages]);
 
   const timeline = useMemo(() => content?.timeline || [], [content?.timeline]);
 
@@ -173,7 +187,7 @@ export const StorySection: React.FC<StorySectionProps> = () => {
                   src={img.src}
                   alt={img.alt}
                   fill
-                  className={`object-cover ${img.objectClass} transition-transform duration-500 group-hover:scale-105`}
+                  className="object-cover object-center transition-transform duration-500 group-hover:scale-105"
                   sizes="(max-width: 768px) 50vw, 25vw"
                 />
                 <div className="absolute inset-0 bg-gradient-to-br from-[#2D1B3D]/10 via-transparent to-[#E8B4B8]/10 group-hover:opacity-0 transition-opacity duration-300" />

--- a/my-app/src/components/admin/content/StoryEditor.tsx
+++ b/my-app/src/components/admin/content/StoryEditor.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState, useRef, useCallback, useMemo } from 'react';
+import Image from 'next/image';
 import type { ContentData } from '@/types/admin';
 
 interface Props {
@@ -11,6 +13,12 @@ const inputClass = "w-full px-3 py-2.5 border border-[#E8B4B8] rounded-lg focus:
 const textareaClass = `${inputClass} resize-y`;
 
 export function StoryEditor({ content, update }: Props) {
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const images = useMemo(() => content.story.images || [], [content.story.images]);
+
   const addItem = () => {
     update(['story', 'timeline'], [...content.story.timeline, { date: '', title: '', text: '' }]);
   };
@@ -25,6 +33,73 @@ export function StoryEditor({ content, update }: Props) {
       content.story.timeline.map((item, i) => i === index ? { ...item, [field]: value } : item)
     );
   };
+
+  const handleUpload = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setUploading(true);
+    setUploadError('');
+
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+
+      const res = await fetch('/api/admin/story-images', {
+        method: 'POST',
+        body: formData,
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setUploadError(data.error || 'Opplasting feilet');
+        return;
+      }
+
+      const newImages = [...images, { url: data.url, alt: 'Alexandra og Tobias', storageName: data.name }];
+      update(['story', 'images'], newImages);
+    } catch {
+      setUploadError('Nettverksfeil ved opplasting');
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  }, [images, update]);
+
+  const removeImage = useCallback(async (index: number) => {
+    const img = images[index];
+
+    // Delete from storage if it has a storageName
+    if (img.storageName) {
+      try {
+        await fetch('/api/admin/story-images', {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: img.storageName }),
+        });
+      } catch {
+        // Continue removing from content even if storage delete fails
+      }
+    }
+
+    update(['story', 'images'], images.filter((_, i) => i !== index));
+  }, [images, update]);
+
+  const updateImageAlt = useCallback((index: number, alt: string) => {
+    update(
+      ['story', 'images'],
+      images.map((img, i) => i === index ? { ...img, alt } : img),
+    );
+  }, [images, update]);
+
+  const moveImage = useCallback((index: number, direction: -1 | 1) => {
+    const target = index + direction;
+    if (target < 0 || target >= images.length) return;
+    const newImages = [...images];
+    [newImages[index], newImages[target]] = [newImages[target], newImages[index]];
+    update(['story', 'images'], newImages);
+  }, [images, update]);
 
   return (
     <section className="bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-md">
@@ -52,6 +127,90 @@ export function StoryEditor({ content, update }: Props) {
             />
           </div>
         </div>
+      </div>
+
+      {/* Image management */}
+      <div className="mb-6">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-sm font-semibold text-[#2D1B3D]">Bilder ({images.length})</h3>
+          <div className="flex items-center gap-2">
+            {uploadError && <span className="text-xs text-red-500">{uploadError}</span>}
+            <label
+              className={`text-sm px-3 py-1.5 rounded-lg transition-colors font-medium cursor-pointer ${
+                uploading
+                  ? 'bg-gray-200 text-gray-400 cursor-wait'
+                  : 'bg-[#E8B4B8]/30 hover:bg-[#E8B4B8]/50 text-[#2D1B3D]'
+              }`}
+            >
+              {uploading ? 'Laster opp...' : '+ Last opp bilde'}
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp,image/gif"
+                onChange={handleUpload}
+                disabled={uploading}
+                className="hidden"
+              />
+            </label>
+          </div>
+        </div>
+
+        {images.length === 0 ? (
+          <p className="text-sm text-[#4A2B5A]/60 italic">
+            Ingen bilder lagt til ennå. Standard plassholder-bilder vises på nettsiden.
+          </p>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            {images.map((img, i) => (
+              <div key={img.storageName || img.url} className="border border-[#E8B4B8]/60 rounded-xl overflow-hidden bg-white/50">
+                <div className="relative aspect-[4/3]">
+                  <Image
+                    src={img.url}
+                    alt={img.alt}
+                    fill
+                    className="object-cover"
+                    sizes="(max-width: 640px) 50vw, 25vw"
+                  />
+                </div>
+                <div className="p-2 space-y-1.5">
+                  <input
+                    type="text"
+                    value={img.alt}
+                    onChange={(e) => updateImageAlt(i, e.target.value)}
+                    className="w-full px-2 py-1 border border-[#E8B4B8]/40 rounded text-xs"
+                    placeholder="Alt-tekst"
+                  />
+                  <div className="flex items-center justify-between">
+                    <div className="flex gap-1">
+                      <button
+                        onClick={() => moveImage(i, -1)}
+                        disabled={i === 0}
+                        className="text-xs px-1.5 py-0.5 rounded bg-[#E8B4B8]/20 hover:bg-[#E8B4B8]/40 disabled:opacity-30 transition-colors"
+                        title="Flytt til venstre"
+                      >
+                        ←
+                      </button>
+                      <button
+                        onClick={() => moveImage(i, 1)}
+                        disabled={i === images.length - 1}
+                        className="text-xs px-1.5 py-0.5 rounded bg-[#E8B4B8]/20 hover:bg-[#E8B4B8]/40 disabled:opacity-30 transition-colors"
+                        title="Flytt til høyre"
+                      >
+                        →
+                      </button>
+                    </div>
+                    <button
+                      onClick={() => removeImage(i)}
+                      className="text-xs text-red-400 hover:text-red-600 transition-colors"
+                    >
+                      Fjern
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       <div className="flex items-center justify-between mb-3">

--- a/my-app/src/lib/content.ts
+++ b/my-app/src/lib/content.ts
@@ -18,6 +18,11 @@ export interface ContentData {
       title: string;
       text: string;
     }>;
+    images?: Array<{
+      url: string;
+      alt: string;
+      storageName?: string;
+    }>;
   };
   weddingDetails: {
     title: string;

--- a/my-app/src/types/admin.ts
+++ b/my-app/src/types/admin.ts
@@ -15,6 +15,11 @@ export interface ContentData {
       title: string;
       text: string;
     }>;
+    images?: Array<{
+      url: string;
+      alt: string;
+      storageName?: string;
+    }>;
   };
   weddingDetails: {
     title: string;


### PR DESCRIPTION
- Add API endpoint for uploading, listing, and deleting story images via Supabase Storage (story-images bucket)
- Update StoryEditor with image upload UI: upload, reorder, delete, and edit alt text for images
- Update StorySection to use dynamic images from content data, falling back to default placeholder images
- Add story images type to ContentData (optional images array)
- Configure Next.js remote image patterns for Supabase domains
- Add default empty images array in content API

https://claude.ai/code/session_01H4edvzvvp2RVabCXNTZDFj